### PR TITLE
Fix relative path tutorial link on homepage

### DIFF
--- a/docs_src/src/routes/index.svelte
+++ b/docs_src/src/routes/index.svelte
@@ -39,7 +39,7 @@
 		<span class="learn-more">learn more</span>
 	</a>
 
-	<a href="tutorial" slot="three">
+	<a href="/tutorial" slot="three">
 		<h2>Fully Featured</h2>
 		<p>Use the full power of Svelte including Transitions, Stores, and Reactivity. One of the smoothest development experiences available for mobile</p>
 		<span class="learn-more">learn more</span>


### PR DESCRIPTION
This fix for #65 should "just work." This makes the tutorial link on the homepage function properly.