### PR TITLE
Fix unexpected tabs in docs examples

### DIFF
--- a/docs_src/src/utils/_sections.js
+++ b/docs_src/src/utils/_sections.js
@@ -4,6 +4,7 @@ import { extract_frontmatter, extract_metadata, langs } from './markdown.js';
 import marked from 'marked';
 
 import PrismJS from 'prismjs';
+import Normalizer from 'prismjs/plugins/normalize-whitespace/prism-normalize-whitespace';
 import 'prismjs/components/prism-bash';
 
 
@@ -38,6 +39,10 @@ export default function (docs_path, anchor_base_url) {
 			const subsections = [];
 			const renderer = new marked.Renderer();
 
+			const codeNormalizer = new Normalizer({
+				'tabs-to-spaces': 4,
+			});
+
 			let block_open = false;
 
 			renderer.hr = (...args) => {
@@ -66,6 +71,8 @@ export default function (docs_path, anchor_base_url) {
 					}
 					if (meta.hidden) return '';
 				}
+
+				source = codeNormalizer.normalize(source)
 
 				const plang = langs[lang];
 				const highlighted = PrismJS.highlight(


### PR DESCRIPTION
Some code blocks it is putting random tabs as indentation (I don't know why). But searching, I found [this solution](https://prismjs.com/plugins/normalize-whitespace/).

Example of unexpected indentation: ![image](https://user-images.githubusercontent.com/1798830/66702884-d6156080-ece2-11e9-8614-87b005262918.png)

In the [source code](https://github.com/halfnelson/svelte-native/blob/master/docs_src/content/docs/10-routing.md), there no tabs but in frontend has :confused: 
