### PR TITLE
Fix unexpected indentation in docs

### DIFF
--- a/docs_src/src/utils/_sections.js
+++ b/docs_src/src/utils/_sections.js
@@ -48,7 +48,7 @@ export default function (docs_path, anchor_base_url) {
 
 			renderer.code = (source, lang) => {
 				source = source.replace(/^ +/gm, match =>
-					match.split('    ').join('\t')
+					match.split('  ').join('\t')
 				);
 
 				const lines = source.split('\n');


### PR DESCRIPTION
Since all code blocks now uses 2 spaces indentation, I just changed the code to convert 2 spaces in one tab.

In my tests it is everything ok now.