### PR TITLE
fix tabContentitem casing to tabContentItem in docs

### DIFF
--- a/docs_src/content/docs/37-tab-navigation.md
+++ b/docs_src/content/docs/37-tab-navigation.md
@@ -72,7 +72,7 @@ A `TabContentItem` contains the view to be displayed when the corresponding TabS
 > **NOTE:** Currently, `TabContentItem` expects a single child element. In most cases, you might want to wrap your content in a layout.
 
 ```html
-<tabContentitem>
+<tabContentItem>
   <stackLayout>
     <label text="Hello From This Tab" />
   </stackLayout>

--- a/docs_src/content/tutorial/05-todo-app-example.md
+++ b/docs_src/content/tutorial/05-todo-app-example.md
@@ -51,12 +51,12 @@ Remove the default `.btn` rule from `app.css` and set the contents of App.svelte
             <tabStripItem title="Completed" />
         </tabStrip>
 
-        <tabContentitem>
+        <tabContentItem>
             <label textWrap="true">This tab will list active tasks and will let users add new tasks.</label>
-        </tabContentitem>
-        <tabContentitem>
+        </tabContentItem>
+        <tabContentItem>
             <label textWrap="true">This tab will list completed tasks for tracking.</label>
-        </tabContentitem>
+        </tabContentItem>
     </tabs>
 </page>
 ```


### PR DESCRIPTION
Consistent casing for element names

Changed: 

```js
<tabContentitem>
	<stackLayout>
		<label text="Hello From This Tab" />
	</stackLayout>
</tabContentItem>
```

to

```js
<tabContentItem>
	<stackLayout>
		<label text="Hello From This Tab" />
	</stackLayout>
</tabContentItem>
```