### PR TITLE
Don't evaluate the template string for a log unless logging is enabled

### DIFF
--- a/src/dom/basicdom/Logger.ts
+++ b/src/dom/basicdom/Logger.ts
@@ -7,33 +7,35 @@ export enum LogLevel {
 
 type LoggerCallback = (message: string, level: LogLevel) => void
 
-const nullLogger = () => { };
-
 class Logger {
     onLog: LoggerCallback
 
     constructor() {
-        this.onLog = () => nullLogger;
+        this.onLog = null;
     }
 
     setHandler(logger: LoggerCallback): void {
-        this.onLog = logger || nullLogger
+        this.onLog = logger
     }
 
-    debug(message: string): void {
-        this.onLog(message, LogLevel.Debug);
+    log(message: () => string, level: LogLevel) {
+        if (this.onLog) this.onLog(message(), level);
     }
 
-    info(message: string): void {
-        this.onLog(message, LogLevel.Info);
+    debug(message: () => string): void {
+        this.log(message, LogLevel.Debug);
     }
 
-    warn(message: string): void {
-        this.onLog(message, LogLevel.Warn);
+    info(message: () => string): void {
+        this.log(message, LogLevel.Info);
     }
 
-    error(message: string): void {
-        this.onLog(message, LogLevel.Error);
+    warn(message: () => string): void {
+        this.log(message, LogLevel.Warn);
+    }
+
+    error(message: () => string): void {
+        this.log(message, LogLevel.Error);
     }
 }
 

--- a/src/dom/basicdom/ViewNode.ts
+++ b/src/dom/basicdom/ViewNode.ts
@@ -95,7 +95,7 @@ export default class ViewNode {
 
     /* istanbul ignore next */
     setText(text: string) {
-        log.debug(`setText ${this} ${text}`)
+        log.debug(() => `setText ${this} ${text}`)
         this.setAttribute('text', text)
     }
 
@@ -108,7 +108,7 @@ export default class ViewNode {
     onRemovedChild(childNode: ViewNode) { }
 
     insertBefore(childNode: ViewNode, referenceNode: ViewNode) {
-        log.debug(`insert before ${this} ${childNode} ${referenceNode}`)
+        log.debug(() => `insert before ${this} ${childNode} ${referenceNode}`)
         if (!childNode) {
             throw new Error(`Can't insert child.`)
         }
@@ -152,7 +152,7 @@ export default class ViewNode {
     }
 
     appendChild(childNode: ViewNode) {
-        log.debug(`append child ${this} ${childNode}`)
+        log.debug(() => `append child ${this} ${childNode}`)
         if (!childNode) {
             throw new Error(`Can't append child.`)
         }
@@ -183,7 +183,7 @@ export default class ViewNode {
     }
 
     removeChild(childNode: ViewNode) {
-        log.debug(`remove child ${this} ${childNode}`)
+        log.debug(() => `remove child ${this} ${childNode}`)
         if (!childNode) {
             throw new Error(`Can't remove child.`)
         }

--- a/src/dom/native/BaseTabNavigationElement.ts
+++ b/src/dom/native/BaseTabNavigationElement.ts
@@ -15,7 +15,7 @@ export default class BaseTabNavigationElement extends NativeViewElementNode<TabN
     onInsertedChild(childNode: ViewNode, index: number) {
         try {
             if (childNode instanceof NativeViewElementNode && childNode.nativeView instanceof TabContentItem) {
-                log.debug(`adding tab content to nav`);
+                log.debug(() => `adding tab content to nav`);
                 this.pendingInserts.push(childNode.nativeView)
                 //wait for next turn so that any content for our tab is attached to the dom
                 Promise.resolve().then(() => {
@@ -36,7 +36,7 @@ export default class BaseTabNavigationElement extends NativeViewElementNode<TabN
     onRemovedChild(childNode: ViewNode) {
         try {
             if (childNode instanceof NativeViewElementNode && childNode.nativeView instanceof TabContentItem) {
-                log.debug(`removing content item from nav`);
+                log.debug(() => `removing content item from nav`);
                 let items = (this.nativeView.items || []).filter(i => i != childNode.nativeView);
                 this.nativeView.items = [];
                 this.nativeView.items = items;

--- a/src/dom/native/FrameElement.ts
+++ b/src/dom/native/FrameElement.ts
@@ -11,7 +11,7 @@ export default class FrameElement extends NativeViewElementNode<Frame> {
 
     setAttribute(key: string, value: any) {
         if (key.toLowerCase() == "defaultpage") {
-            log.debug(`loading page ${value}`);
+            log.debug(() => `loading page ${value}`);
             let dummy = createElement('fragment');
             let page = new (value as any)({ target: dummy, props: {} });
             (this.nativeView as Frame).navigate({ create: () => (dummy.firstElement() as NativeViewElementNode<View>).nativeView });

--- a/src/dom/native/ListViewElement.ts
+++ b/src/dom/native/ListViewElement.ts
@@ -25,7 +25,7 @@ export class SvelteKeyedTemplate {
     createView(): View {
         //create a proxy element to eventually contain our item (once we have one to render)
         //TODO is StackLayout the best choice here? 
-        log.debug(`creating view for key ${this.key}`)
+        log.debug(() => `creating view for key ${this.key}`)
         let wrapper = createElement('StackLayout') as NativeViewElementNode<View>;
         wrapper.setStyle("padding", 0)
         wrapper.setStyle("margin", 0)
@@ -55,7 +55,7 @@ export default class ListViewElement extends NativeViewElementNode<ListView> {
         let items = listView.items;
 
         if (args.index >= items.length) {
-            log.error(`Got request for item at index that didn't exist ${args.index}`)
+            log.error(() => `Got request for item at index that didn't exist ${args.index}`)
             return;
         }
 
@@ -69,20 +69,20 @@ export default class ListViewElement extends NativeViewElementNode<ListView> {
             let component;
 
             if (args.view && (args.view as any).__SvelteComponentBuilder__) {
-                log.debug(`instantiating component in keyed view item at ${args.index}`);
+                log.debug(() => `instantiating component in keyed view item at ${args.index}`);
                 //now we have an item, we can create and mount this component
                 (args.view as any).__SvelteComponentBuilder__({ item });
                 (args.view as any).__SvelteComponentBuilder__ = null; //free the memory
                 return;
             }
 
-            log.debug(`creating default view for item at ${args.index}`)
+            log.debug(() => `creating default view for item at ${args.index}`)
             if (typeof listView.itemTemplates == "object") {
                 component = listView.itemTemplates.filter(x => x.key == "default").map(x => (x as SvelteKeyedTemplate).component)[0]
             }
 
             if (!component) {
-                log.error(`Couldn't determine component to use for item at ${args.index}`);
+                log.error(() => `Couldn't determine component to use for item at ${args.index}`);
                 return;
             }
             let wrapper = createElement('ProxyViewContainer') as NativeViewElementNode<View>;
@@ -98,7 +98,7 @@ export default class ListViewElement extends NativeViewElementNode<ListView> {
             args.view = nativeEl;
         } else {
             let componentInstance: SvelteComponent = (args.view as any).__SvelteComponent__
-            log.debug(`updating view for ${args.index} which is a ${args.view}`)
+            log.debug(() => `updating view for ${args.index} which is a ${args.view}`)
             componentInstance.$set({ item })
         }
     }
@@ -107,7 +107,7 @@ export default class ListViewElement extends NativeViewElementNode<ListView> {
         super.onInsertedChild(childNode, index);
         if (childNode instanceof TemplateElement) {
             let key = childNode.getAttribute('key') || "default"
-            log.debug(`Adding template for key ${key}`);
+            log.debug(() => `Adding template for key ${key}`);
             if (!this.nativeView.itemTemplates || typeof this.nativeView.itemTemplates == "string") {
                 this.nativeView.itemTemplates = []
             }

--- a/src/dom/native/NativeElementNode.ts
+++ b/src/dom/native/NativeElementNode.ts
@@ -83,7 +83,7 @@ export default class NativeElementNode<T> extends ElementNode {
         this._normalizedKeys = getNormalizedKeysForObject(this._nativeElement, Object.keys(this.propConfig));
 
         (this._nativeElement as any).__SvelteNativeElement__ = this;
-        log.debug(`created ${this} ${this._nativeElement}`)
+        log.debug(() => `created ${this} ${this._nativeElement}`)
     }
 
     get nativeElement() {
@@ -209,11 +209,11 @@ export default class NativeElementNode<T> extends ElementNode {
                 setTarget = setTarget[key];
             } else {
                 try {
-                    log.debug(`setAttr value ${this} ${resolvedKeys.join(".")} ${value}`)
+                    log.debug(() => `setAttr value ${this} ${resolvedKeys.join(".")} ${value}`)
                     setTarget[key] = value
                 } catch (e) {
                     // ignore but log
-                    log.error(`set attribute threw an error, attr:${key} on ${this._tagName}: ${e.message}`)
+                    log.error(() => `set attribute threw an error, attr:${key} on ${this._tagName}: ${e.message}`)
                 }
             }
         }

--- a/src/dom/native/NativeViewElementNode.ts
+++ b/src/dom/native/NativeViewElementNode.ts
@@ -1,5 +1,5 @@
 import ViewNode from '../basicdom/ViewNode'
-import { logger as log, registerElement } from '../basicdom'
+import { logger as log, registerElement, RegisterElementOptions } from '../basicdom'
 import { KeyframeAnimation } from '@nativescript/core/ui/animation/keyframe-animation';
 import { CssAnimationParser } from '@nativescript/core/ui/styling/css-animation-parser';
 import { Page, View, EventData, ContentView } from '@nativescript/core/ui/page';
@@ -50,7 +50,7 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
         let oldAnimations: KeyframeAnimation[] = [];
 
         const addAnimation = (animation: string) => {
-            log.debug(`Adding animation ${animation}`)
+            log.debug(() => `Adding animation ${animation}`)
             if (!this.nativeView) {
                 throw Error("Attempt to apply animation to tag without a native view" + this.tagName);
             }
@@ -94,7 +94,7 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
         }
 
         const removeAnimation = (animation: string) => {
-            log.debug(`Removing animation ${animation}`)
+            log.debug(() => `Removing animation ${animation}`)
             if (animations.has(animation)) {
                 let animationInstance = animations.get(animation);
                 animations.delete(animation);
@@ -122,7 +122,7 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
             },
 
             set animation(value: string) {
-                log.debug(`setting animation ${value}`)
+                log.debug(() => `setting animation ${value}`)
                 let new_animations = value.trim() == "" ? [] : value.split(',').map(a => a.trim());
                 //add new ones
                 for (let anim of new_animations) {
@@ -139,12 +139,12 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
             },
 
             get cssText(): string {
-                log.debug("got css text");
+                log.debug(() => "got css text");
                 return getStyleAttribute();
             },
 
             set cssText(value: string) {
-                log.debug("set css text");
+                log.debug(() => "set css text");
                 setStyleAttribute(value);
             }
         }
@@ -152,7 +152,7 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
 
     /* istanbul ignore next */
     setStyle(property: string, value: string | number) {
-        log.debug(`setStyle ${this} ${property} ${value}`)
+        log.debug(() => `setStyle ${this} ${property} ${value}`)
 
         if (!(value = value.toString().trim()).length) {
             return
@@ -176,13 +176,13 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
 
     /* istanbul ignore next */
     addEventListener(event: string, handler: EventListener) {
-        log.debug(`add event listener ${this} ${event}`)
+        log.debug(() => `add event listener ${this} ${event}`)
         this.nativeView.on(event, handler)
     }
 
     /* istanbul ignore next */
     removeEventListener(event: string, handler?: EventListener) {
-        log.debug(`remove event listener ${this} ${event}`)
+        log.debug(() => `remove event listener ${this} ${event}`)
         this.nativeView.off(event, handler)
     }
 
@@ -271,7 +271,7 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
         } else if (parentView instanceof View) {
             parentView._removeView(childView)
         } else {
-                log.warn("Unknown parent view type: " + parentView)
+                log.warn(() => "Unknown parent view type: " + parentView)
             }
         }
 

--- a/src/dom/native/TabStripElement.ts
+++ b/src/dom/native/TabStripElement.ts
@@ -15,7 +15,7 @@ export default class TabStripElement extends NativeViewElementNode<TabStrip> {
         // is to set items to [] before setting it to the new array.
         try {
             if (childNode instanceof NativeViewElementNode && childNode.nativeView instanceof TabStripItem) {
-                log.debug(`adding tab strip item ${childNode.nativeView.title}`);
+                log.debug(() => `adding tab strip item ${childNode.nativeView.title}`);
                 const items = this.nativeView.items || [];
                 this.nativeView.items = [];
                 this.nativeView.items = items.concat([childNode.nativeView]);
@@ -30,7 +30,7 @@ export default class TabStripElement extends NativeViewElementNode<TabStrip> {
     onRemovedChild(childNode: ViewNode) {
         try {
             if (childNode instanceof NativeViewElementNode && childNode.nativeView instanceof TabStripItem) {
-                log.debug(`removing tab strip item ${childNode.nativeView.title}`);
+                log.debug(() => `removing tab strip item ${childNode.nativeView.title}`);
                 let items = (this.nativeView.items || []).filter(i => i != childNode.nativeView);
                 this.nativeView.items = [];
                 this.nativeView.items = items;

--- a/src/dom/native/TabViewElement.ts
+++ b/src/dom/native/TabViewElement.ts
@@ -11,7 +11,7 @@ export default class TabViewElement extends NativeViewElementNode<TabView> {
 
     doUpdate() {
         let items = this.childNodes.filter(x => x instanceof NativeViewElementNode && x.nativeView instanceof TabViewItem).map(x => (x as any).nativeView as TabViewItem);
-        log.debug(`updating tab items. now has ${items.length} items`);
+        log.debug(() => `updating tab items. now has ${items.length} items`);
         (this.nativeView as TabView).items = items;
     }
 

--- a/src/dom/navigation.ts
+++ b/src/dom/navigation.ts
@@ -26,7 +26,7 @@ function resolveFrame(frameSpec: FrameSpec): Frame {
     if (frameSpec instanceof Frame) targetFrame = frameSpec;
     if (typeof frameSpec == "string") {
         targetFrame = Frame.getFrameById(frameSpec)
-        if (!targetFrame) log.error(`Navigate could not find frame with id ${frameSpec}`)
+        if (!targetFrame) log.error(() => `Navigate could not find frame with id ${frameSpec}`)
     }
     return targetFrame;
 }

--- a/src/dom/svelte/StyleElement.ts
+++ b/src/dom/svelte/StyleElement.ts
@@ -13,7 +13,7 @@ class StyleSheet {
     deleteRule(index: number) {
         let removed = this._rules.splice(index, 1);
         for (let r in removed) {
-            log.debug(`removing transition rule ${r}`);
+            log.debug(() => `removing transition rule ${r}`);
             // Turns out nativescript doesn't support "removing" css.
             // this is pretty horrible but better than a memory leak. 
             // since this code is called mainly for keyframes, and keyframes don't add new selectors (they just end up in _keyframes)
@@ -31,7 +31,7 @@ class StyleSheet {
     }
 
     insertRule(rule: string, index: number = 0) {
-        log.debug(`Adding transition rule ${rule}`);
+        log.debug(() => `Adding transition rule ${rule}`);
         let frame = topmost();
         frame.addCss(rule);
         this._rules.splice(index, 0, rule);

--- a/src/dom/svelte/SvelteNativeDocument.ts
+++ b/src/dom/svelte/SvelteNativeDocument.ts
@@ -9,12 +9,12 @@ export default class SvelteNativeDocument extends DocumentNode {
         this.head = createElement('head')
         this.appendChild(this.head);
 
-        log.debug(`created ${this}`)
+        log.debug(() => `created ${this}`)
     }
 
     createTextNode(text: string) {
         const el = new TextNode(text)
-        log.debug(`created ${el}`)
+        log.debug(() => `created ${el}`)
         return el;
     }
 


### PR DESCRIPTION
Rough benchmark says that template strings are slower than an if statement. using lazy evaluated function speeds up the log lines when logging is disabled.