### PR TITLE
fix for component not being N Views

### DIFF
--- a/src/dom/native/NativeViewElementNode.ts
+++ b/src/dom/native/NativeViewElementNode.ts
@@ -259,12 +259,12 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
         //childnodes with propAttributes aren't added to native views
         if (childNode.propAttribute) return;
 
-        if (!this.nativeView || !childNode.nativeView) {
+        const parentView = this.nativeView
+        const childView = childNode.nativeView
+        if (!parentView || !childView || !(childView instanceof View)) {
             return
         }
 
-        const parentView = this.nativeView
-        const childView = childNode.nativeView
 
         if (parentView instanceof LayoutBase) {
             parentView.removeChild(childView)


### PR DESCRIPTION
I have a few plugins where some "child" components are actually not N Views.
For example i wrote a new label component where spans are simple objects and not N Views to get better performances.
However Svelte tries to remove those spans from their parent (which is in fact an N View).
And then it fails with an error like that (the example happens during listview refresh and cells cleanup)
```
Error: View not added to this instance. View: [Group] CurrentParent: undefined ExpectedParent: (56)[Group][Span]<testSpan>[Group][Group][Group][Group]
  at <unknown>(ViewBase._removeView(<embedded>:37:346549)
  at <unknown>(onRemovedChild(<embedded>:37:240883)
  at <unknown>(removeChild(<embedded>:37:231135)
  at <unknown>(removeChild(<embedded>:37:231986)
  at <unknown>(detach(<embedded>:37:2611)
```