### PR TITLE
[docs] Fix NativeScript link on homepage

### DIFF
--- a/docs_src/src/routes/index.svelte
+++ b/docs_src/src/routes/index.svelte
@@ -61,7 +61,7 @@
 		<span class="learn-more">learn more</span>
 	</a>
 
-	<a href="https://www.nativescript.org/about" slot="two">
+	<a href="https://www.nativescript.org" slot="two">
 		<h2>Using NativeScript</h2>
 		<p>Build cross-platform, native iOS and Android apps without web views. Get truly native UI and performance while sharing skills and code with the web</p>
 		<span class="learn-more">learn more</span>


### PR DESCRIPTION
The **Using NativeScript** link on the Svelte Native homepage is dead. I've updated it to the NativeScript homepage, which I think makes sense.

![Using NativeScript](https://user-images.githubusercontent.com/62207708/84125221-871ff680-aa3c-11ea-9d54-acaf3c2471c0.png)
