### PR TITLE
fix: allow let:index on Template

### DIFF
--- a/src/components/Template.svelte
+++ b/src/components/Template.svelte
@@ -1,6 +1,6 @@
 <template {...$$props} component="{template}" xmlns="tns" />
 <AsComponent bind:component="{template}" let:props>
-    <slot item="{(props ? props.item : null)}" />
+    <slot item="{(props ? props.item : null)}" index="{(props ? props.index : null)}" />
 </AsComponent>
 
 


### PR DESCRIPTION
This could also be released before 7.0