### PR TITLE
fix: Allow non "View" children to be removed

### DIFF
--- a/src/dom/native/NativeViewElementNode.ts
+++ b/src/dom/native/NativeViewElementNode.ts
@@ -274,7 +274,7 @@ export default class NativeViewElementNode<T extends View> extends NativeElement
             if (childNode.nodeType === 8) {
                 parentView._removeView(childView)
             }
-        } else if (parentView instanceof View) {
+        } else if (typeof parentView._removeView === 'function') {
             parentView._removeView(childView)
         } else {
                 log.warn(() => "Unknown parent view type: " + parentView)


### PR DESCRIPTION
Some of my plugins (alternative to span for example, or my canvas plugin) have "child" views (span, shape for the canvas plugin) which are actually not `View` though they conform to it. It increases performances by a thousand because they dont need to go through all the heavy stuff from Views and layouts.
That fix allows those Non Views to be correctly removed without breaking anything