### PR TITLE
feat: allow apps to register elements itself

### DIFF
--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -91,7 +91,7 @@ export function initializeDom() {
     registerSvelteElements();
     // TODO: move __AUTO_REGISTER_UI_MODULES__ out of global
     // breaking change needs to be in sync with N webpack release
-    if (!global.__AUTO_REGISTER_UI_MODULES__) {
+    if (global.__AUTO_REGISTER_UI_MODULES__ !== false) {
         registerNativeElements();
     }
     return installGlobalShims();

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -16,6 +16,8 @@ export { default as ActionBarElement } from './native/ActionBarElement'
 export { default as FrameElement } from "./native/FrameElement"
 export { default as TabsElement } from './native/TabsElement'
 export { default as PageElement } from './native/PageElement'
+export { default as TabViewElement } from './native/TabViewElement'
+export { default as TabStripElement } from './native/TabStripElement'
 export { default as ListViewElement, SvelteKeyedTemplate } from './native/ListViewElement'
 export { default as BottomNavigationElement } from './native/BottomNavigationElement'
 
@@ -87,6 +89,10 @@ function initializeLogger() {
 export function initializeDom() {
     initializeLogger();
     registerSvelteElements();
-    registerNativeElements();
+    // TODO: move __AUTO_REGISTER_UI_MODULES__ out of global
+    // breaking change needs to be in sync with N webpack release
+    if (!global.__AUTO_REGISTER_UI_MODULES__) {
+        registerNativeElements();
+    }
     return installGlobalShims();
 }

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -89,10 +89,6 @@ function initializeLogger() {
 export function initializeDom() {
     initializeLogger();
     registerSvelteElements();
-    // TODO: move __AUTO_REGISTER_UI_MODULES__ out of global
-    // breaking change needs to be in sync with N webpack release
-    if (global.__AUTO_REGISTER_UI_MODULES__ !== false) {
-        registerNativeElements();
-    }
+    registerNativeElements();
     return installGlobalShims();
 }

--- a/src/dom/nativescript-elements.ts
+++ b/src/dom/nativescript-elements.ts
@@ -12,147 +12,151 @@ import TabStripElement from './native/TabStripElement';
 
 
 export function registerNativeElements() {
-  registerNativeViewElement(
-    'ActionItem',
-    () => require('@nativescript/core').ActionItem,
-    'actionItems'
-  )
+  // TODO: move __AUTO_REGISTER_UI_MODULES__ out of global
+  // breaking change needs to be in sync with N webpack release
+  if (global.__AUTO_REGISTER_UI_MODULES__ !== false) {
+    registerNativeViewElement(
+      'ActionItem',
+      () => require('@nativescript/core').ActionItem,
+      'actionItems'
+    )
 
-  registerNativeViewElement(
-    'NavigationButton',
-    () => require('@nativescript/core').NavigationButton,
-    'navigationButton'
-  )
+    registerNativeViewElement(
+      'NavigationButton',
+      () => require('@nativescript/core').NavigationButton,
+      'navigationButton'
+    )
 
 
-  registerNativeViewElement(
-    'TabViewItem',
-    () => require('@nativescript/core').TabViewItem
-  )
+    registerNativeViewElement(
+      'TabViewItem',
+      () => require('@nativescript/core').TabViewItem
+    )
 
-  registerNativeViewElement('Label', () => require('@nativescript/core').Label)
-  
-  registerNativeViewElement(
-    'DatePicker',
-    () => require('@nativescript/core').DatePicker,
-  )
+    registerNativeViewElement('Label', () => require('@nativescript/core').Label)
+    
+    registerNativeViewElement(
+      'DatePicker',
+      () => require('@nativescript/core').DatePicker,
+    )
 
-  registerNativeViewElement(
-    'AbsoluteLayout',
-    () => require('@nativescript/core').AbsoluteLayout
-  )
-  registerNativeViewElement(
-    'ActivityIndicator',
-    () => require('@nativescript/core').ActivityIndicator
-  )
-  registerNativeViewElement('Button', () => require('@nativescript/core').Button)
-  registerNativeViewElement(
-    'ContentView',
-    () => require('@nativescript/core').ContentView
-  )
-  registerNativeViewElement(
-    'DockLayout',
-    () => require('@nativescript/core').DockLayout
-  )
-  registerNativeViewElement(
-    'GridLayout',
-    () => require('@nativescript/core').GridLayout
-  )
-  registerNativeViewElement(
-    'HtmlView',
-    () => require('@nativescript/core').HtmlView
-  )
-  registerNativeViewElement('Image', () => require('@nativescript/core').Image)
-  registerNativeViewElement(
-    'ListPicker',
-    () => require('@nativescript/core').ListPicker,
-  )
+    registerNativeViewElement(
+      'AbsoluteLayout',
+      () => require('@nativescript/core').AbsoluteLayout
+    )
+    registerNativeViewElement(
+      'ActivityIndicator',
+      () => require('@nativescript/core').ActivityIndicator
+    )
+    registerNativeViewElement('Button', () => require('@nativescript/core').Button)
+    registerNativeViewElement(
+      'ContentView',
+      () => require('@nativescript/core').ContentView
+    )
+    registerNativeViewElement(
+      'DockLayout',
+      () => require('@nativescript/core').DockLayout
+    )
+    registerNativeViewElement(
+      'GridLayout',
+      () => require('@nativescript/core').GridLayout
+    )
+    registerNativeViewElement(
+      'HtmlView',
+      () => require('@nativescript/core').HtmlView
+    )
+    registerNativeViewElement('Image', () => require('@nativescript/core').Image)
+    registerNativeViewElement(
+      'ListPicker',
+      () => require('@nativescript/core').ListPicker,
+    )
 
-  registerNativeViewElement(
-    'Placeholder',
-    () => require('@nativescript/core').Placeholder
-  )
-  registerNativeViewElement(
-    'Progress',
-    () => require('@nativescript/core').Progress,
-  )
-  registerNativeViewElement(
-    'ProxyViewContainer',
-    () => require('@nativescript/core').ProxyViewContainer
-  )
-  // registerElement(
-  //   'Repeater',
-  //   () => require('@nativescript/core').Repeater
-  // )
-  registerNativeViewElement(
-    'ScrollView',
-    () => require('@nativescript/core').ScrollView
-  )
-  registerNativeViewElement(
-    'SearchBar',
-    () => require('@nativescript/core').SearchBar,
-  )
-  registerNativeViewElement(
-    'SegmentedBar',
-    () => require('@nativescript/core').SegmentedBar,
-    null,
-    { "items": NativeElementPropType.Array }
-  )
-  registerNativeViewElement(
-    'SegmentedBarItem',
-    () => require('@nativescript/core').SegmentedBarItem,
-    "items"
-  )
-  registerNativeViewElement('Slider', () => require('@nativescript/core').Slider)
-  registerNativeViewElement(
-    'StackLayout',
-    () => require('@nativescript/core').StackLayout
-  )
-  registerNativeViewElement(
-    'FlexboxLayout',
-    () => require('@nativescript/core').FlexboxLayout
-  )
-  registerNativeViewElement('Switch', () => require('@nativescript/core').Switch)
+    registerNativeViewElement(
+      'Placeholder',
+      () => require('@nativescript/core').Placeholder
+    )
+    registerNativeViewElement(
+      'Progress',
+      () => require('@nativescript/core').Progress,
+    )
+    registerNativeViewElement(
+      'ProxyViewContainer',
+      () => require('@nativescript/core').ProxyViewContainer
+    )
+    // registerElement(
+    //   'Repeater',
+    //   () => require('@nativescript/core').Repeater
+    // )
+    registerNativeViewElement(
+      'ScrollView',
+      () => require('@nativescript/core').ScrollView
+    )
+    registerNativeViewElement(
+      'SearchBar',
+      () => require('@nativescript/core').SearchBar,
+    )
+    registerNativeViewElement(
+      'SegmentedBar',
+      () => require('@nativescript/core').SegmentedBar,
+      null,
+      { "items": NativeElementPropType.Array }
+    )
+    registerNativeViewElement(
+      'SegmentedBarItem',
+      () => require('@nativescript/core').SegmentedBarItem,
+      "items"
+    )
+    registerNativeViewElement('Slider', () => require('@nativescript/core').Slider)
+    registerNativeViewElement(
+      'StackLayout',
+      () => require('@nativescript/core').StackLayout
+    )
+    registerNativeViewElement(
+      'FlexboxLayout',
+      () => require('@nativescript/core').FlexboxLayout
+    )
+    registerNativeViewElement('Switch', () => require('@nativescript/core').Switch)
 
-  registerNativeViewElement(
-    'TextField',
-    () => require('@nativescript/core').TextField,
+    registerNativeViewElement(
+      'TextField',
+      () => require('@nativescript/core').TextField,
 
-  )
-  registerNativeViewElement(
-    'TextView',
-    () => require('@nativescript/core').TextView,
+    )
+    registerNativeViewElement(
+      'TextView',
+      () => require('@nativescript/core').TextView,
 
-  )
-  registerNativeViewElement(
-    'TimePicker',
-    () => require('@nativescript/core').TimePicker,
+    )
+    registerNativeViewElement(
+      'TimePicker',
+      () => require('@nativescript/core').TimePicker,
 
-  )
-  registerNativeViewElement(
-    'WebView',
-    () => require('@nativescript/core').WebView
-  )
-  registerNativeViewElement(
-    'WrapLayout',
-    () => require('@nativescript/core').WrapLayout
-  )
+    )
+    registerNativeViewElement(
+      'WebView',
+      () => require('@nativescript/core').WebView
+    )
+    registerNativeViewElement(
+      'WrapLayout',
+      () => require('@nativescript/core').WrapLayout
+    )
 
-  registerNativeViewElement('FormattedString', () => require('@nativescript/core').FormattedString, "formattedText", {
-    "spans": NativeElementPropType.ObservableArray
-  })
+    registerNativeViewElement('FormattedString', () => require('@nativescript/core').FormattedString, "formattedText", {
+      "spans": NativeElementPropType.ObservableArray
+    })
 
-  registerNativeViewElement('Span', () => require('@nativescript/core').Span, "spans")
+    registerNativeViewElement('Span', () => require('@nativescript/core').Span, "spans")
 
-  registerElement('ActionBar', () => new ActionBarElement())
-  registerElement('Frame', () => new FrameElement())
-  registerElement('Page', () => new PageElement())
-  registerElement('ListView', () => new ListViewElement())
-  registerElement('TabView', () => new TabViewElement())
+    registerElement('ActionBar', () => new ActionBarElement())
+    registerElement('Frame', () => new FrameElement())
+    registerElement('Page', () => new PageElement())
+    registerElement('ListView', () => new ListViewElement())
+    registerElement('TabView', () => new TabViewElement())
 
-  registerElement('BottomNavigation', () => new BottomNavigationElement())
-  registerElement('Tabs', () => new TabsElement())
-  registerElement('TabStrip', () => new TabStripElement());
-  registerNativeViewElement('TabStripItem', () => require('@nativescript/core').TabStripItem);
-  registerNativeViewElement('TabContentItem', () => require('@nativescript/core').TabContentItem);
+    registerElement('BottomNavigation', () => new BottomNavigationElement())
+    registerElement('Tabs', () => new TabsElement())
+    registerElement('TabStrip', () => new TabStripElement());
+    registerNativeViewElement('TabStripItem', () => require('@nativescript/core').TabStripItem);
+    registerNativeViewElement('TabContentItem', () => require('@nativescript/core').TabContentItem);
+  }
 }

--- a/src/dom/nativescript-elements.ts
+++ b/src/dom/nativescript-elements.ts
@@ -11,7 +11,6 @@ import ActionBarElement from './native/ActionBarElement';
 import TabStripElement from './native/TabStripElement';
 
 
-
 export function registerNativeElements() {
   registerNativeViewElement(
     'ActionItem',


### PR DESCRIPTION
This gets very important with webpack 5 which will be able to completely remove unused components. This needs a PR from N https://github.com/NativeScript/NativeScript/pull/9133 to be fully functional.
However this is already an improvement in webpack 4 as app “loading” will get faster.

Also if at one point we manage to "auto" detect used components that flag should also be set to `false`

I am creating that PR now because it could already be used by users who wants faster loading time. And it does not break anything nor change the default behavior.