### PR TITLE
remove requestAnimationFrame overload

### DIFF
--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -30,16 +30,6 @@ function installGlobalShims(): SvelteNativeDocument {
 
     window.window = global;
     window.document = new SvelteNativeDocument();
-
-    // As of NS 6.3, the NS provided requestAnimationFrame breaks svelte by invoking the callback immediately 
-    // instead of next event loop, We force ours instead.
-    Object.defineProperty(global, 'requestAnimationFrame', {
-        value: (action: (now: DOMHighResTimeStamp) => {}) => {
-            setTimeout(() => action(window.performance.now()), 33); //about 30 fps
-        },
-        configurable: true,
-        writable: true,
-    })
     
     window.getComputedStyle = (node: NativeViewElementNode<View>) => {
         return node.nativeView.style;


### PR DESCRIPTION
With N 8  and i would suppose 7 too this is not needed anymore.
```
console.log('One');
requestAnimationFrame(() => console.log('Two'));
console.log('Three');
```
will print 
```
One
Three
Two