### PR TITLE
fix: output 2019 and let webpack handle transpilation if need be

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,11 @@
     "compilerOptions": {
       "baseUrl": ".",
       "declaration": true,
-      "module": "es2015",
+      "module": "esnext",
       "noImplicitAny": true,
       "outDir": "./dist",
       "rootDir": "src",
-      "target": "es6",
+      "target": "es2019",
       "moduleResolution": "node",
       "skipLibCheck": true,
       "allowSyntheticDefaultImports": false,


### PR DESCRIPTION
I think it should work on both iOS and Android. 
It will make svelte-native bundle a bit smaller and faster on android

If you could create an alpha with this i could test if it works correctly

Thanks