### PR TITLE
fix typings

### DIFF
--- a/src/components/Template.svelte.d.ts
+++ b/src/components/Template.svelte.d.ts
@@ -1,8 +1,10 @@
-export default class AsComponent extends SvelteComponent {
+import type { SvelteComponentTyped } from "svelte";
+export default class AsComponent<T = any> extends SvelteComponentTyped<T> {
     $$prop_def: {
         key?: string;
     }
     $$slot_def: {
-        item: unknown;
+        item: T;
+        default: any;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,12 @@ declare global {
         constructor(options: { target?: ViewNode | Element , props?: any, anchor?: ViewNode | Element, intro?: boolean });
         $set(props: any): void;
     }
+    interface Svelte2TsxComponentConstructorParameters<T> {
+        target?: ViewNode | Element;
+        props?: T;
+        anchor?: ViewNode | Element;
+        intro?: boolean;
+    }
 }
 
 export function svelteNativeNoFrame(rootElement: typeof SvelteComponent, data: any): Promise<SvelteComponent> {


### PR DESCRIPTION
* Svelte2TsxComponentConstructorParameters fix 
* new `Template` typings for latest svelte and language-tools

This all works nicely with the new vscode setting (soon to be default) https://github.com/sveltejs/language-tools/pull/1237