### PR TITLE
feat: recommend ns create to init new projects

### DIFF
--- a/docs_src/src/routes/index.svelte
+++ b/docs_src/src/routes/index.svelte
@@ -86,10 +86,9 @@
 	<div style="grid-area: start; display: flex; flex-direction: column; min-width: 0" slot="how">
 		<pre class="language-bash" style="margin: 0 0 1em 0; min-width: 0; min-height: 0">
 npm install -g nativescript
-npx degit halfnelson/svelte-native-template my-mobile-app
+ns create my-mobile-app --svelte
 cd my-mobile-app
 
-npm install
 ns run android
 		</pre>
 


### PR DESCRIPTION
ref: https://github.com/NativeScript/NativeScript/issues/10007

The ns create template is pulled from https://github.com/NativeScript/nativescript-app-templates/tree/main/packages/template-blank-svelte
We try to keep these updated & working for every ns update (CI in place to verify the projects can be created & built as a safety net).

@halfnelson let me know if that works for you & we can give you write access to the templates repo in case you need to make any changes.