### PR TITLE
Update URLs to preview app

### DIFF
--- a/docs_src/content/docs/01-getting-started.md
+++ b/docs_src/content/docs/01-getting-started.md
@@ -20,8 +20,8 @@ Check it worked by running `ns`:
 
 Svelte-Native really is native, so it needs a mobile device to run. The build setup for iOS or Android can be a pain, so the wizards at Nativescript have created the NativeScript playground app. This allows us to run Svelte-Native application code without having to build the full mobile application.
 
-[<img src="/media/app-store.png" alt="Get if rom the App Store">](https://itunes.apple.com/us/app/nativescript-playground/id1263543946?mt=8&amp;ls=1)
-[<img src="/media/google-play.png" alt="Get it from Google Play">](https://play.google.com/store/apps/details?id=org.nativescript.play)
+[<img src="/media/app-store.png" alt="Get if rom the App Store">](https://preview.nativescript.org/ios)
+[<img src="/media/google-play.png" alt="Get it from Google Play">](https://preview.nativescript.org/android)
 
 #### Create a new Svelte-Native app
 


### PR DESCRIPTION
URLs to preview apps have changed. Updated to new URLs that are used on https://preview.nativescript.org/