### PR TITLE
fix: setting an attribute to null would not update N view

### DIFF
--- a/src/dom/native/NativeElementNode.ts
+++ b/src/dom/native/NativeElementNode.ts
@@ -155,6 +155,12 @@ export default class NativeElementNode<T> extends ElementNode {
         super.onRemovedChild(childNode)
     }
 
+    removeAttribute(name) {
+        // if an attribute is set to null svelte will call removeAttribute
+        // but we still need to call setAttribute to apply the change on N view
+        this.setAttribute(name, null);
+    }
+
     setAttribute(fullkey: string, value: any) {
         const nv = this.nativeElement as any
         let setTarget = nv;


### PR DESCRIPTION
In svelte if an attribute is set to null it calls `removeAttribute` for which `NativeElementNode` does nothing. But N needs to know of the change.
So we call `setAttribute`