### PR TITLE
fix: Live-sync reloading entire view tree

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
-import { Application } from '@nativescript/core'
+import { Application, View } from '@nativescript/core';
 import { navigate, ViewNode, createElement, initializeDom, FrameElement, NativeElementNode } from './dom';
-import { View } from '@nativescript/core';
 import { DocumentNode } from './dom/basicdom';
 import type {SvelteComponent} from './ambient.js';
+
+// Override this function as the default is currently resetting entire content on NativeScript
+global.__onLiveSyncCore = () => {
+    Application.getRootView()?._onCssStateChange();
+};
 
 export function svelteNativeNoFrame<T>(rootElement: typeof SvelteComponent<T>, data: T): Promise<SvelteComponent<T>> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Right now, all components are reloaded during HMR on android platform. That is because NativeScript is resetting activity content  on live-sync. The culprit: https://github.com/NativeScript/NativeScript/blob/main/packages/core/ui/frame/index.android.ts#L105

To counter this for the time being, we have to override `global.__onLiveSyncCore` like all flavors do.

I copied the one from NativeScript-Vue which for some kind of reason updates CSS state.
https://github.com/nativescript-vue/nativescript-vue/blob/main/src/nativescript/index.ts#L12

@farfromrefug I thought it'd be suitable to put this in index file but let me know if you have any better ideas.