### PR TITLE
chore: add a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I noticed that most of the open PRs are from dependabot, which I think is pretty noisy by default. This PR will have dependabot ignore minor/patch upgrades and only attempt major upgrades to spare the distraction in the PR queue. This file only affects dependency updates, so dependabot may still send minor/patch upgrades if a dependency has a security issue